### PR TITLE
Unit Test: lockup.rs

### DIFF
--- a/src/ft_token_receiver.rs
+++ b/src/ft_token_receiver.rs
@@ -89,11 +89,10 @@ mod tests {
             one_near.as_yoctonear().into(),
             serde_json::to_string(&lockup_create).unwrap(),
         );
-        if let PromiseOrValue::Value(v) = value {
-            assert_eq!(v.0, 0);
-        } else {
-            panic!("failed expectation!")
-        }
+        assert!(
+            matches!(value, PromiseOrValue::Value(v) if v.0 == 0),
+            "failed expectation!"
+        );
     }
 
     #[test]

--- a/src/ft_token_receiver.rs
+++ b/src/ft_token_receiver.rs
@@ -29,7 +29,7 @@ impl FungibleTokenReceiver for Contract {
         match ft_message {
             FtMessage::LockupCreate(lockup_create) => {
                 let lockup = lockup_create.into_lockup(&sender_id);
-                lockup.assert_new_valid(amount);
+                lockup.assert_valid(amount);
                 let index = self.internal_add_lockup(&lockup);
                 log!(
                     "Created new lockup for {} with index {}",

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,22 @@ pub(crate) fn nano_to_sec(timestamp: Timestamp) -> u128 {
     (timestamp / 10u64.pow(9)) as u128
 }
 
-// TODO - DO NOT USE BLOCK TIME! USE BLOCK NUMBER!
 pub(crate) fn current_timestamp_sec() -> U128 {
     U128(nano_to_sec(env::block_timestamp()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nano_to_sec() {
+        assert_eq!(nano_to_sec(1_719_234_571_328_277_000), 1_719_234_571);
+    }
+
+    #[test]
+    fn test_current_timestamp_sec() {
+        // env is working on a fresh blockchain starting from time 0
+        assert_eq!(current_timestamp_sec().0, 0);
+    }
 }


### PR DESCRIPTION
Adding as many tests as possible without `VMContext`. Missing test of claim because we can't move `near_sdk::env::block_time()` forward.