### PR TITLE
Unit Test: Terminate Lockup

### DIFF
--- a/src/termination.rs
+++ b/src/termination.rs
@@ -60,3 +60,113 @@ impl Lockup {
         (unvested_balance, termination_config.beneficiary_id)
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_terminate() {
+        let account_id: AccountId = "x.near".parse().unwrap();
+        let total_balance = NearToken::from_near(1);
+        let timestamp = U128(1);
+        let schedule = Schedule::new_unlocked_since(total_balance, timestamp);
+        let mut lockup = Lockup {
+            account_id: account_id.clone(),
+            schedule: schedule.clone(),
+            claimed_balance: ZERO_NEAR,
+            termination_config: Some(TerminationConfig {
+                beneficiary_id: account_id.clone(),
+                vesting_schedule: VestingConditions::SameAsLockupSchedule,
+            }),
+        };
+
+        let (unvested_amount, beneficiary) = lockup.terminate(None, timestamp);
+        assert_eq!(unvested_amount.as_yoctonear(), 0);
+        assert_eq!(beneficiary, account_id);
+    }
+
+    #[test]
+    #[should_panic = "No termination config"]
+    fn test_terminate_fail() {
+        let account_id: AccountId = "x.near".parse().unwrap();
+        let total_balance = NearToken::from_near(1);
+        let timestamp = U128(1);
+        let schedule = Schedule::new_unlocked_since(total_balance, timestamp);
+
+        let mut lockup = Lockup {
+            account_id: account_id.clone(),
+            schedule: schedule.clone(),
+            claimed_balance: ZERO_NEAR,
+            termination_config: None,
+        };
+
+        lockup.terminate(None, timestamp);
+    }
+
+    #[test]
+    #[should_panic = "Revealed schedule required for the termination"]
+    fn test_terminate_hashed_without_schedule() {
+        let account_id: AccountId = "x.near".parse().unwrap();
+        let total_balance = NearToken::from_near(1);
+        let timestamp = U128(1);
+        let schedule = Schedule::new_unlocked_since(total_balance, timestamp);
+
+        let mut lockup = Lockup {
+            account_id: account_id.clone(),
+            schedule: schedule.clone(),
+            claimed_balance: ZERO_NEAR,
+            termination_config: Some(TerminationConfig {
+                beneficiary_id: account_id.clone(),
+                vesting_schedule: VestingConditions::Hash(schedule.hash().into()),
+            }),
+        };
+
+        lockup.terminate(None, timestamp);
+    }
+
+    #[test]
+    fn test_terminate_hashed_with_schedule() {
+        let account_id: AccountId = "x.near".parse().unwrap();
+        let total_balance = NearToken::from_near(1);
+        let timestamp = U128(1);
+        let schedule = Schedule::new_unlocked_since(total_balance, timestamp);
+
+        let mut lockup = Lockup {
+            account_id: account_id.clone(),
+            schedule: schedule.clone(),
+            claimed_balance: ZERO_NEAR,
+            termination_config: Some(TerminationConfig {
+                beneficiary_id: account_id.clone(),
+                vesting_schedule: VestingConditions::Hash(schedule.hash().into()),
+            }),
+        };
+
+        let (unvested_amount, beneficiary) = lockup.terminate(Some(schedule), timestamp);
+        assert_eq!(unvested_amount.as_yoctonear(), 0);
+        assert_eq!(beneficiary, account_id);
+    }
+
+    #[test]
+    fn test_terminate_with_schedule_vesting_conditions() {
+        let account_id: AccountId = "x.near".parse().unwrap();
+        let total_balance = NearToken::from_near(1);
+        let timestamp = U128(1);
+        let schedule = Schedule::new_unlocked_since(total_balance, timestamp);
+
+        let mut lockup = Lockup {
+            account_id: account_id.clone(),
+            schedule: schedule.clone(),
+            claimed_balance: ZERO_NEAR,
+            termination_config: Some(TerminationConfig {
+                beneficiary_id: account_id.clone(),
+                vesting_schedule: VestingConditions::Schedule(schedule),
+            }),
+        };
+
+        let (unvested_amount, beneficiary) = lockup.terminate(None, timestamp);
+        assert_eq!(unvested_amount.as_yoctonear(), 0);
+        assert_eq!(beneficiary, account_id);
+    }
+}


### PR DESCRIPTION
We can't fast forward time so I can't test this block:

```rs
        if unvested_balance > ZERO_NEAR {
            self.schedule
                .terminate(vested_balance, termination_timestamp);
        }
```

Its still unclear to me what a `termination_config: VestingConditions` are supposed to be. Seems a bit like there are two different schedules involved.